### PR TITLE
Customize slack channel

### DIFF
--- a/config.pl-dist
+++ b/config.pl-dist
@@ -277,6 +277,7 @@ $notify = {
         'push_paused'         => 0,
         'push_resumed'        => 0,
         'webhook_url'         => 'https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXX/XXXXXXXXXXXXXXXXX', #webhook url
+        'channel'             => '', # '@myuser', '#notifications', etc. '' uses default channel configured in the Slack webhook
         'message'             => '{user}',
     },
 

--- a/config.pl-dist-win32
+++ b/config.pl-dist-win32
@@ -241,6 +241,7 @@ $notify = {
         'push_paused'         => 0,
         'push_resumed'        => 0,
         'webhook_url'         => 'https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXX/XXXXXXXXXXXXXXXXX', #webhook url
+        'channel'             => '', # '@myuser', '#notifications', etc. '' uses default channel configured in the Slack webhook
         'message'             => '{user}',
     },
 

--- a/plexWatch.pl
+++ b/plexWatch.pl
@@ -169,6 +169,7 @@ GetOptions(\%options,
            'backup',
            'clean_extras',
            'show_xml',
+           'slack_channel:s',
            'help|?'
     ) or pod2usage(2);
 pod2usage(-verbose => 2) if (exists($options{'help'}));
@@ -2367,6 +2368,7 @@ sub NotifySlack() {
     $sk{'message'} .= ' ' . $alert;
 
     my $channel = $sk{'channel'};
+    if ($options{'slack_channel'}) { $channel = $options{'slack_channel'}; }
     my %post = ('text' => $sk{'message'}, 'channel' => $channel);
     my $json = encode_json \%post;
     my $url = $sk{'webhook_url'};
@@ -4389,6 +4391,8 @@ plexWatch.pl [options]
    --clean_extras                 Remove any trailers or extras from the plexWatch DB
 
    --exclude_library_id=...       Full exclusion for a library section id. It will not log or notify.
+
+   --slack_channel                Slack channel or user override to notify. '--slack_channel=#notifications', '--slack_channel=@myuser'
 
    #############################################################################################
 

--- a/plexWatch.pl
+++ b/plexWatch.pl
@@ -2366,7 +2366,8 @@ sub NotifySlack() {
     $sk{'message'} .= ' ' . ucfirst($alert_options->{'item_type'}) if $alert_options->{'item_type'};
     $sk{'message'} .= ' ' . $alert;
 
-    my %post = ('text' => $sk{'message'});
+    my $channel = $sk{'channel'};
+    my %post = ('text' => $sk{'message'}, 'channel' => $channel);
     my $json = encode_json \%post;
     my $url = $sk{'webhook_url'};
     


### PR DESCRIPTION
This PR adds support for configuring the destination for Slack messages.
1. You can set `'channel' => '#mychannel'` or `'channel' => '@myuser'` in `config.pl` to override the destination configured in the Slack webhook
   - Not providing this value at all (or setting it to an empty string) will use whatever is configured in the Slack webhook.
2. You can pass `--slack_channel=#mychannel` or `--slack_channel=@myuser` from the command line to override the config setting.
   - This can be useful, for example, to send each user direct messages with their playback notifications, e.g. `--notify --user=jack --slack_channel=@jack`
