### PR TITLE
Support 'username' in the slack configuration

### DIFF
--- a/config.pl-dist
+++ b/config.pl-dist
@@ -277,7 +277,8 @@ $notify = {
         'push_paused'         => 0,
         'push_resumed'        => 0,
         'webhook_url'         => 'https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXX/XXXXXXXXXXXXXXXXX', #webhook url
-        'channel'             => '', # '@myuser', '#notifications', etc. '' uses default channel configured in the Slack webhook
+        'channel'             => '', # '@myuser', '#notifications', etc. ('' uses default channel configured in the Slack webhook)
+        'username'            => '', # username to send notifications as ('' uses default configured in Slack webhook)
         'message'             => '{user}',
     },
 

--- a/config.pl-dist-win32
+++ b/config.pl-dist-win32
@@ -241,7 +241,8 @@ $notify = {
         'push_paused'         => 0,
         'push_resumed'        => 0,
         'webhook_url'         => 'https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXX/XXXXXXXXXXXXXXXXX', #webhook url
-        'channel'             => '', # '@myuser', '#notifications', etc. '' uses default channel configured in the Slack webhook
+        'channel'             => '', # '@myuser', '#notifications', etc. ('' uses default channel configured in the Slack webhook)
+        'username'            => '', # username to send notifications as ('' uses default configured in Slack webhook)
         'message'             => '{user}',
     },
 

--- a/plexWatch.pl
+++ b/plexWatch.pl
@@ -2369,7 +2369,7 @@ sub NotifySlack() {
 
     my $channel = $sk{'channel'};
     if ($options{'slack_channel'}) { $channel = $options{'slack_channel'}; }
-    my %post = ('text' => $sk{'message'}, 'channel' => $channel);
+    my %post = ('text' => $sk{'message'}, 'channel' => $channel, 'username' => $sk{'username'});
     my $json = encode_json \%post;
     my $url = $sk{'webhook_url'};
     


### PR DESCRIPTION
This allows you to use the same Slack webhook with multiple instances of plexWatch and have each of them identified distinctly when notifications are sent (e.g. with the server name).
